### PR TITLE
Fixes to subCommands. Fixes for registry

### DIFF
--- a/Heimdall-TS/src/handlers/tickets/create-ticket.ts
+++ b/Heimdall-TS/src/handlers/tickets/create-ticket.ts
@@ -93,16 +93,8 @@ class CreateTicketButtonCommand extends BaseCommand {
         ],
       });
       const newTicketMessage = await newTicketChannel.send({
-        content: 'Ticket Menu',
-        components: [
-          new ActionRowBuilder<ButtonBuilder>().setComponents(
-            new ButtonBuilder()
-              .setCustomId('close-ticket')
-              .setStyle(ButtonStyle.Danger)
-              .setLabel('close Ticket')
-              .setEmoji('🎟')
-          ),
-        ],
+        content:
+          'Please explain your issue. A member of tech support will be with you shortly.',
       });
       ticketRepository.update(
         { id: savedTicket.id },

--- a/Heimdall-TS/src/subcommands/spooktober/index.ts
+++ b/Heimdall-TS/src/subcommands/spooktober/index.ts
@@ -52,8 +52,8 @@ class SpooktoberSubCommand extends BaseSlashSubCommand {
                   .setRequired(true)
                   .addChannelTypes(
                     ChannelType.GuildText,
-                    ChannelType.GuildPrivateThread,
-                    ChannelType.GuildPublicThread
+                    ChannelType.PrivateThread,
+                    ChannelType.PublicThread
                   )
               )
           )
@@ -68,8 +68,8 @@ class SpooktoberSubCommand extends BaseSlashSubCommand {
                   .setRequired(true)
                   .addChannelTypes(
                     ChannelType.GuildText,
-                    ChannelType.GuildPrivateThread,
-                    ChannelType.GuildPublicThread
+                    ChannelType.PrivateThread,
+                    ChannelType.PublicThread
                   )
               )
           )

--- a/Heimdall-TS/src/subcommands/tickets/index.ts
+++ b/Heimdall-TS/src/subcommands/tickets/index.ts
@@ -58,6 +58,10 @@ class TicketSubCommand extends BaseSlashSubCommand {
               .setRequired(true)
           )
       )
+      .addSubcommand((subcommand) =>
+        subcommand.setName('close').setDescription('Close the ticket')
+      )
+
       .toJSON();
   }
 }

--- a/Heimdall-TS/src/utils/registry.ts
+++ b/Heimdall-TS/src/utils/registry.ts
@@ -39,13 +39,11 @@ export const registerSubCommands = async (
       subcommandDirectoryFiles.splice(indexFilePos, 1);
 
       try {
-        let BaseSubcommand = await require(path.join(
-          filePath,
-          file,
-          'index.js'
-        )).default;
-
-        if (!BaseSubcommand) {
+        let BaseSubcommand;
+        try {
+          BaseSubcommand = await require(path.join(filePath, file, 'index.ts'))
+            .default;
+        } catch (error) {
           BaseSubcommand = await require(path.join(filePath, file, 'index.js'))
             .default;
         }


### PR DESCRIPTION
SubCommands now use the correct Channel Types

Registry.ts now has a check to see whether the index. is in JS or TS and deals with it respectively.

subCommand for closing tickets was added.